### PR TITLE
Modify script to update only when necessary; expose colors & separator as command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ format-foreground = #d0d060
 exec = taskbar
 ```
 
+The colors can also be customized from the exec option as given below:
+```shell
+exec = taskbar --activebg "#000" --inactivebg "#303030" --fg "#eaeaea"
+```
+
 ## Demo Video
 
 ![](demo/demo.gif)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Place the script in any of the `$PATH` for example
 ```conf
 [module/windows]
 type = custom/script
-interval = 0
+tail = true
 format = "<label>"
 format-prefix = "  "
 format-prefix-foreground = #111111

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ format-foreground = #d0d060
 exec = taskbar
 ```
 
-The colors can also be customized from the exec option as given below:
+The colors and/or separator character can also be customized from the exec option as given below:
 ```shell
-exec = taskbar --activebg "#000" --inactivebg "#303030" --fg "#eaeaea"
+exec = taskbar --activebg "#000" --inactivebg "#303030" --fg "#eaeaea" --separator "·"
 ```
 
 ## Demo Video

--- a/taskbar
+++ b/taskbar
@@ -3,6 +3,7 @@
 ACTIVE_BG_COLOR="#222"
 INACTIVE_BG_COLOR="#323232"
 FG_COLOR="#d0d0d0"
+SEPARATOR=""
 
 while [[ $# -gt 0 ]]; do
     KEY="$1"
@@ -10,6 +11,7 @@ while [[ $# -gt 0 ]]; do
         --activebg) ACTIVE_BG_COLOR="$2";;
         --inactivebg) INACTIVE_BG_COLOR="$2";;
         --fg) FG_COLOR="$2";;
+        --separator) SEPARATOR="$2";;
         *) echo "Unknown option $KEY.";;
     esac
     shift
@@ -25,11 +27,11 @@ while read LINE; do
         for WINDOW in "${WINDOW_LIST[@]}"; do
             FOCUS="$( bspc query -N -n )"
             [[ "$FOCUS" == "$WINDOW" ]] && BG_COLOR="$ACTIVE_BG_COLOR" || BG_COLOR="$INACTIVE_BG_COLOR"
-            TITLE="$(xdotool getwindowname $WINDOW | sed 's/^.*-\s//g' | sed -E 's/(–.*$)?(\s?\(.*\))?//g')"
+            TITLE="$( xdotool getwindowname $WINDOW | sed 's/^.*-\s//g' | sed -E 's/(–.*$)?(\s?\(.*\))?//g' )"
             MAX_LENGTH=$(((${#TITLE}*5)/100))
             [ $MAX_LENGTH -gt 0 ] && TITLE="$( echo $TITLE | sed -E "s/.{$MAX_LENGTH}$/.../" )" || TITLE=$TITLE
-            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$BG_COLOR}%{F$FG_COLOR}  $TITLE%{A}%{u-} "
+            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$BG_COLOR}%{F$FG_COLOR} $SEPARATOR $TITLE%{A}%{u-} "
         done
         echo -e "$MODULE_STR\n\c"
     fi
-done < <( echo && bspc subscribe node_focus desktop_focus monitor_focus )
+done < <( echo && bspc subscribe node_focus node_add node_remove desktop_focus monitor_focus )

--- a/taskbar
+++ b/taskbar
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
 
-ACTIVE_COLOR="#222"
-INACTIVE_COLOR="#323232"
+ACTIVE_BG_COLOR="#222"
+INACTIVE_BG_COLOR="#323232"
+FG_COLOR="#d0d0d0"
 
 while read LINE; do
     mapfile -t WINDOW_LIST < <( bspc query -N -n .window -d focused )
     if [ ${#WINDOW_LIST[@]} -eq 0 ]; then
-        echo "%{B#323232}%{F#d0d0d0} --- %{u-}"
+        echo "%{B#$INACTIVE_BG_COLOR}%{F#$FG_COLOR} --- %{u-}"
     else
         MODULE_STR=""
         for WINDOW in "${WINDOW_LIST[@]}"; do
             FOCUS="$( bspc query -N -n )"
-            [[ "$FOCUS" == "$WINDOW" ]] && COLOR="$ACTIVE_COLOR" || COLOR="$INACTIVE_COLOR"
+            [[ "$FOCUS" == "$WINDOW" ]] && BG_COLOR="$ACTIVE_BG_COLOR" || BG_COLOR="$INACTIVE_BG_COLOR"
             TITLE="$(xdotool getwindowname $WINDOW | sed 's/^.*-\s//g' | sed -E 's/(–.*$)?(\s?\(.*\))?//g')"
             MAX_LENGTH=$(((${#TITLE}*5)/100))
             [ $MAX_LENGTH -gt 0 ] && TITLE="$( echo $TITLE | sed -E "s/.{$MAX_LENGTH}$/.../" )" || TITLE=$TITLE
-            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$COLOR}%{F#d0d0d0}  $TITLE%{A}%{u-} "
+            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$BG_COLOR}%{F#$FG_COLOR}  $TITLE%{A}%{u-} "
         done
         echo -e "$MODULE_STR\n\c"
     fi

--- a/taskbar
+++ b/taskbar
@@ -4,10 +4,22 @@ ACTIVE_BG_COLOR="#222"
 INACTIVE_BG_COLOR="#323232"
 FG_COLOR="#d0d0d0"
 
+while [[ $# -gt 0 ]]; do
+    KEY="$1"
+    case $KEY in
+        --activebg) ACTIVE_BG_COLOR="$2";;
+        --inactivebg) INACTIVE_BG_COLOR="$2";;
+        --fg) FG_COLOR="$2";;
+        *) echo "Unknown option $KEY.";;
+    esac
+    shift
+    shift
+done
+
 while read LINE; do
     mapfile -t WINDOW_LIST < <( bspc query -N -n .window -d focused )
     if [ ${#WINDOW_LIST[@]} -eq 0 ]; then
-        echo "%{B#$INACTIVE_BG_COLOR}%{F#$FG_COLOR} --- %{u-}"
+        echo "%{B$INACTIVE_BG_COLOR}%{F$FG_COLOR} --- %{u-}"
     else
         MODULE_STR=""
         for WINDOW in "${WINDOW_LIST[@]}"; do
@@ -16,8 +28,8 @@ while read LINE; do
             TITLE="$(xdotool getwindowname $WINDOW | sed 's/^.*-\s//g' | sed -E 's/(–.*$)?(\s?\(.*\))?//g')"
             MAX_LENGTH=$(((${#TITLE}*5)/100))
             [ $MAX_LENGTH -gt 0 ] && TITLE="$( echo $TITLE | sed -E "s/.{$MAX_LENGTH}$/.../" )" || TITLE=$TITLE
-            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$BG_COLOR}%{F#$FG_COLOR}  $TITLE%{A}%{u-} "
+            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$BG_COLOR}%{F$FG_COLOR}  $TITLE%{A}%{u-} "
         done
         echo -e "$MODULE_STR\n\c"
     fi
-done < <( bspc subscribe node_focus desktop_focus monitor_focus )
+done < <( echo && bspc subscribe node_focus desktop_focus monitor_focus )

--- a/taskbar
+++ b/taskbar
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
-if [ -z "$(bspc query -N -n .window -d focused)" ]; then
-    echo "%{B#323232}%{F#d0d0d0} --- %{u-}"
-fi
+ACTIVE_COLOR="#222"
+INACTIVE_COLOR="#323232"
 
-for WINDOW in $(bspc query -N -n .window -d focused)
-do
-    FOCUS=`bspc query -N -n`
-    [[ "$FOCUS" == "$WINDOW" ]] && COLOR="#222" || COLOR="#323232"
-    TITLE=$(xdotool getwindowname $WINDOW | sed 's/^.*-\s//g' | sed -E 's/(–.*$)?(\s?\(.*\))?//g')
-    MAX_LENGTH=$(((${#TITLE}*5)/100))
-    [ $MAX_LENGTH -gt 0 ] && TITLE=`echo $TITLE | sed -E "s/.{$MAX_LENGTH}$/.../"` || TITLE=$TITLE
-    echo -e "%{A1:bspc node -f $WINDOW:}%{B$COLOR}%{F#d0d0d0}  $TITLE%{A}%{u-} \c"
-done
-
+while read LINE; do
+    mapfile -t WINDOW_LIST < <( bspc query -N -n .window -d focused )
+    if [ ${#WINDOW_LIST[@]} -eq 0 ]; then
+        echo "%{B#323232}%{F#d0d0d0} --- %{u-}"
+    else
+        MODULE_STR=""
+        for WINDOW in "${WINDOW_LIST[@]}"; do
+            FOCUS="$( bspc query -N -n )"
+            [[ "$FOCUS" == "$WINDOW" ]] && COLOR="$ACTIVE_COLOR" || COLOR="$INACTIVE_COLOR"
+            TITLE="$(xdotool getwindowname $WINDOW | sed 's/^.*-\s//g' | sed -E 's/(–.*$)?(\s?\(.*\))?//g')"
+            MAX_LENGTH=$(((${#TITLE}*5)/100))
+            [ $MAX_LENGTH -gt 0 ] && TITLE="$( echo $TITLE | sed -E "s/.{$MAX_LENGTH}$/.../" )" || TITLE=$TITLE
+            MODULE_STR="${MODULE_STR}%{A1:bspc node -f $WINDOW:}%{B$COLOR}%{F#d0d0d0}  $TITLE%{A}%{u-} "
+        done
+        echo -e "$MODULE_STR\n\c"
+    fi
+done < <( bspc subscribe node_focus desktop_focus monitor_focus )


### PR DESCRIPTION
This PR has the necessary modifications for updating on the basis of bspwm events, which can be checked using the `bspc subscribe` command. This, in conjunction with the `tail = true` option on the Polybar side of things, will let the module update only when necessary.

These modifications also expose the colors (and the separator) as command line arguments so that configuration can be done from a single place.